### PR TITLE
feat: add notification actions, SMS integration, and event creation

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -14,7 +14,7 @@ import (
 
 	This seeds two rulesv2 examples:
 	- EVENT_STATUS_CHANGED → logs when a schedule becomes Completed
-	- DAILY_COMPETENCY_EXPIRY_CHECK → logs when a required competency expires in ≤ 7 days
+	- DAILY_COMPETENCY_EXPIRY_CHECK → logs when a required competency expires in <= 7 days
 */
 
 func main() {
@@ -36,6 +36,8 @@ func main() {
 
 	// Register a simple console action so we can see results without email/webhooks
 	reg.UseAction("CONSOLE", consoleAction{})
+	reg.UseAction("create_event", &rules.CreateEventAction{DB: DB})
+	reg.UseAction("notification", &rules.NotificationAction{DB: DB})
 
 	// 4) Create the store
 	// store := rules.DBRuleStore{DB: DB}
@@ -101,4 +103,3 @@ func (consoleAction) Execute(ctx rules.EvalContext, params map[string]any) error
 	log.Printf("[CONSOLE] now=%s msg=%q params=%v", ctx.Now.Format(time.RFC3339), msg, params)
 	return nil
 }
-


### PR DESCRIPTION
# Notification and Event Creation Actions CLOSES #220 

- Added event creation in the actions

- Added notifications to the actions


- Registered new action in the main and the integration

- Need to add sms api key pwease

- Test pass (well the new tests for my actions)
![b6k7b0tn11kf1](https://github.com/user-attachments/assets/e0f0ea47-d104-4369-bce1-73b044d9cca0)