### PR TITLE
Fixed Bugs on Event definitions page and Calendar Page

### DIFF
--- a/frontend/src/components/ui/EventDeleteConfirmationModal.tsx
+++ b/frontend/src/components/ui/EventDeleteConfirmationModal.tsx
@@ -39,8 +39,12 @@ const EventDeleteConfirmationModal: React.FC<EventDeleteConfirmationModalProps> 
             
             if (isDefinition && err instanceof ApiError) {
                 const msg = String(err.data?.error || err.message || '').toLowerCase();
-                if ([400, 409, 423].includes(err.status) || msg.includes('in use') || msg.includes('linked') || msg.includes('foreign key')) {
-                    setError('This event definition is linked to one or more scheduled events and cannot be deleted at this time. Remove or update those schedules first.');
+                if ([400, 409, 423].includes(err.status) || msg.includes('in use') || msg.includes('linked') || msg.includes('foreign key') || msg.includes('granted competencies')) {
+                    if (msg.includes('granted competencies')) {
+                        setError('This event definition has scheduled events that granted competencies to employees and cannot be deleted. Please contact an administrator if you need to remove this definition.');
+                    } else {
+                        setError('This event definition is linked to one or more scheduled events and cannot be deleted at this time. Remove or update those schedules first.');
+                    }
                     return;
                 }
             }

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -230,7 +230,21 @@ const CalendarPage: React.FC = () => {
     const handleDeletionSuccess = () => {
         if (!eventToDelete) return;
         const calendarApi = calendarRef.current?.getApi();
-        calendarApi?.getEventById(eventToDelete.id)?.remove();
+        
+        // For multi-day events, we need to remove all instances with the same seriesId
+        const seriesId = eventToDelete.extendedProps.seriesId;
+        if (seriesId) {
+            // Remove all instances of this multi-day event
+            const allEvents = calendarApi?.getEvents() || [];
+            allEvents.forEach(event => {
+                if (event.extendedProps.seriesId === seriesId) {
+                    event.remove();
+                }
+            });
+        } else {
+            // Single day event, just remove the specific event
+            calendarApi?.getEventById(eventToDelete.id)?.remove();
+        }
         
         setIsDeleteModalOpen(false);
         setEventToDelete(null);
@@ -530,7 +544,7 @@ const CalendarPage: React.FC = () => {
                         setEventToDelete(null);
                     }}
                     onDeleteSuccess={handleDeletionSuccess}
-                    eventId={Number((eventToDelete as any).extendedProps?.scheduleId)}
+                    eventId={Number(eventToDelete.extendedProps?.scheduleId)}
                     eventName={eventToDelete.title}
                 />
             )}

--- a/frontend/src/pages/EventDefinitionsPage.tsx
+++ b/frontend/src/pages/EventDefinitionsPage.tsx
@@ -176,7 +176,24 @@ const EventDefinitionsPage: React.FC = () => {
                                             <td className="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                                                 <div className="flex items-center justify-end space-x-4">
                                                     <button onClick={() => handleEditClick(def)} className="text-custom-secondary hover:text-custom-third dark:text-dark-third dark:hover:text-dark-secondary"><Edit size={16} /></button>
-                                                    <button onClick={() => handleDeleteRequest(def)} className="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300"><Trash2 size={16} /></button>
+                                                    {def.canDelete !== false ? (
+                                                        <button onClick={() => handleDeleteRequest(def)} className="text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300"><Trash2 size={16} /></button>
+                                                    ) : (
+                                                        <div className="relative group">
+                                                            <button 
+                                                                disabled 
+                                                                className="text-gray-400 cursor-not-allowed dark:text-gray-600"
+                                                                title={def.hasLinkedSchedules ? 'Cannot delete: this event definition has scheduled events that granted competencies to employees' : 'Cannot delete this event definition'}
+                                                            >
+                                                                <Trash2 size={16} />
+                                                            </button>
+                                                            {def.hasLinkedSchedules && (
+                                                                <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 bg-gray-800 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap z-10 pointer-events-none">
+                                                                    Cannot delete: has scheduled events that granted competencies
+                                                                </div>
+                                                            )}
+                                                        </div>
+                                                    )}
                                                 </div>
                                             </td>
                                         </tr>

--- a/frontend/src/services/eventService.ts
+++ b/frontend/src/services/eventService.ts
@@ -9,7 +9,9 @@ export interface EventDefinition {
     GrantsCertificateID?: number;
     Facilitator: string;
     CreatedBy: string;
-    CreationDate: string; 
+    CreationDate: string;
+    canDelete?: boolean;
+    hasLinkedSchedules?: boolean;
 }
 
 export type CreateEventDefinitionPayload = Omit<EventDefinition, 'CustomEventID' | 'CreatedBy' | 'CreationDate'>;

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -117,6 +117,12 @@ func TestGetEventDefinitionsHandler_Unit(t *testing.T) {
 			AddRow(1, "Event 1").
 			AddRow(2, "Event 2"))
 
+	// Expect competency checking query
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT DISTINCT ces.custom_event_id AS id FROM custom_event_schedules ces INNER JOIN employee_competencies ec ON ec.granted_by_schedule_id = ces.custom_event_schedule_id WHERE ces.custom_event_id IN ($1,$2)`)).
+		WithArgs(1, 2).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
 	c, rec := ctxWithJSON(t, db, "GET", "/event-definitions", nil)
 	GetEventDefinitionsHandler(c)
 
@@ -141,6 +147,12 @@ func TestGetEventDefinitionsHandler_NonAdmin_FilteredByCreator_Unit(t *testing.T
 		WithArgs(testUserEmail).
 		WillReturnRows(sqlmock.NewRows([]string{"custom_event_id", "event_name", "created_by"}).
 			AddRow(7, "Mine", testUserEmail))
+
+	// Expect competency checking query
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT DISTINCT ces.custom_event_id AS id FROM custom_event_schedules ces INNER JOIN employee_competencies ec ON ec.granted_by_schedule_id = ces.custom_event_schedule_id WHERE ces.custom_event_id IN ($1)`)).
+		WithArgs(7).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
 	GetEventDefinitionsHandler(c)
 
@@ -235,6 +247,12 @@ func TestDeleteEventDefinitionHandler_Unit(t *testing.T) {
 		`SELECT * FROM "custom_event_definitions" WHERE "custom_event_definitions"."custom_event_id" = $1 ORDER BY "custom_event_definitions"."custom_event_id" LIMIT $2`)).
 		WithArgs(defID, 1).
 		WillReturnRows(sqlmock.NewRows([]string{"custom_event_id"}).AddRow(defID))
+
+	// Expect competency check query
+	mock.ExpectQuery(regexp.QuoteMeta(
+		`SELECT COUNT(*) FROM custom_event_schedules ces INNER JOIN employee_competencies ec ON ec.granted_by_schedule_id = ces.custom_event_schedule_id WHERE ces.custom_event_id = $1`)).
+		WithArgs(defID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
 	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta(

--- a/internal/event/handler.go
+++ b/internal/event/handler.go
@@ -109,7 +109,7 @@ func GetEventDefinitionsHandler(c *gin.Context) {
 	var definitions []models.CustomEventDefinition
 
 	// Determine caller role; non-admin/HR users should only see their own definitions
-	_, _, isAdmin, isHR, err := currentUserContextFn(c)
+	currentUser, _, isAdmin, isHR, err := currentUserContextFn(c)
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
 		return
@@ -132,7 +132,64 @@ func GetEventDefinitionsHandler(c *gin.Context) {
 			return
 		}
 	}
-	c.JSON(http.StatusOK, definitions)
+
+	// Check which definitions have linked scheduled events that grant competencies
+	definitionIds := make([]int, 0, len(definitions))
+	for _, def := range definitions {
+		definitionIds = append(definitionIds, def.CustomEventID)
+	}
+
+	hasLinkedSchedulesMap := map[int]bool{}
+	if len(definitionIds) > 0 {
+		// Check if any definition has scheduled events that have granted competencies
+		var rows []struct{ ID int }
+		DB.Raw(`
+			SELECT DISTINCT ces.custom_event_id AS id
+			FROM custom_event_schedules ces
+			INNER JOIN employee_competencies ec ON ec.granted_by_schedule_id = ces.custom_event_schedule_id
+			WHERE ces.custom_event_id IN ?
+		`, definitionIds).Scan(&rows)
+		for _, r := range rows {
+			hasLinkedSchedulesMap[r.ID] = true
+		}
+	}
+
+	// Build response DTOs with permission flags
+	type definitionDTO struct {
+		models.CustomEventDefinition
+		CanDelete           bool `json:"canDelete"`
+		HasLinkedSchedules  bool `json:"hasLinkedSchedules"`
+	}
+
+	out := make([]definitionDTO, 0, len(definitions))
+	for _, def := range definitions {
+		canManage := false
+		if isAdmin || isHR {
+			canManage = true
+		} else if currentUser != nil {
+			// Check if current user created this definition
+			emailVal, _ := c.Get("email")
+			email := ""
+			if emailVal != nil {
+				email = emailVal.(string)
+			}
+			canManage = def.CreatedBy == email
+		}
+
+		// Check if this definition has linked schedules that granted competencies
+		hasLinkedSchedules := hasLinkedSchedulesMap[def.CustomEventID]
+		
+		// Can delete only if user can manage AND the definition hasn't granted competencies through scheduled events
+		canDelete := canManage && !hasLinkedSchedules
+
+		out = append(out, definitionDTO{
+			CustomEventDefinition: def,
+			CanDelete:             canDelete,
+			HasLinkedSchedules:    hasLinkedSchedules,
+		})
+	}
+
+	c.JSON(http.StatusOK, out)
 }
 
 // UpdateEventDefinitionHandler updates an existing event definition.
@@ -230,6 +287,25 @@ func DeleteEventDefinitionHandler(c *gin.Context) {
 			c.JSON(http.StatusForbidden, gin.H{"error": "You are not permitted to delete this event definition"})
 			return
 		}
+	}
+
+	// Check if this definition has scheduled events that have granted competencies to any employees
+	var competencyCount int64
+	if err := DB.Raw(`
+		SELECT COUNT(*)
+		FROM custom_event_schedules ces
+		INNER JOIN employee_competencies ec ON ec.granted_by_schedule_id = ces.custom_event_schedule_id
+		WHERE ces.custom_event_id = ?
+	`, definitionID).Scan(&competencyCount).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check competency grants"})
+		return
+	}
+
+	if competencyCount > 0 {
+		c.JSON(http.StatusConflict, gin.H{
+			"error": "Cannot delete this event definition as it has scheduled events that granted competencies to employees. Please contact an administrator if you need to remove this definition.",
+		})
+		return
 	}
 
 	result := DB.Delete(&models.CustomEventDefinition{}, definitionID)

--- a/mobile/src/services/eventDefinitions.ts
+++ b/mobile/src/services/eventDefinitions.ts
@@ -9,6 +9,8 @@ export type EventDefinition = {
   Facilitator: string;
   CreatedBy: string;
   CreationDate: string;
+  canDelete?: boolean;
+  hasLinkedSchedules?: boolean;
 };
 
 export type CreateEventDefinitionPayload = {


### PR DESCRIPTION
## Bugs fixed:
- I disabled the delete button from event definitions that have been used to grant competencies to employees as this violates a foreign key constraint.

- I also fixed the delete bug on the Calendar page that originally did not work for deleting an event due to the multi day styling logically error.

This completes the event definitions check box under the Fix basic bugs issue. #336 